### PR TITLE
Update help text for secure:enable

### DIFF
--- a/commands
+++ b/commands
@@ -55,7 +55,7 @@ case "$1" in
 
     if [[ ! -f "$HTPASSWD_FILE" ]]; then
       echo "Error: no htpasswd file"
-      echo "Add users with dokku secure:add before enabling"
+      echo "Add users with dokku secure:set before enabling"
       exit 1
     fi
 


### PR DESCRIPTION
It said "Add users with dokku secure:add before enabling" while the command is `secure:set`
